### PR TITLE
Add logger.log()

### DIFF
--- a/debug-logger.js
+++ b/debug-logger.js
@@ -27,7 +27,7 @@ exports.levels = {
     namespaceSuffix : ':debug'
   },
   log : {
-    color : getForeColor('green'),
+    color : '',
     prefix : '      LOG    '
   },
   info : {

--- a/debug-logger.js
+++ b/debug-logger.js
@@ -26,6 +26,10 @@ exports.levels = {
     prefix :       'DEBUG  ',
     namespaceSuffix : ':debug'
   },
+  log : {
+    color : getForeColor('green'),
+    prefix : '      LOG    '
+  },
   info : {
     color : getForeColor('green'),
     prefix : '      INFO   '


### PR DESCRIPTION
I use the `debug-logger` to replace `console.*`. This adds the only method that is supported by `console` and isn't by `debug-logger`, which is `logger.log()`
