### PR TITLE
v0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A thin wrapper for visionmedia's debug logger, adding levels and colored output.
 
 ## Overview
 [visionmedia/debug](https://github.com/visionmedia/debug) is a ubitiquous logging library with 1000+ dependants. Given how widespread it is and the convenience of namespaces it is a great logger for library modules.
-`debug-logger` is a convenicence wrapper around `debug` that adds level based coloured output. Each instance of `debug-logger` contains 2 instances of `debug`, one for general purpose logging and another using `namespace:debug` for debug logs.
+`debug-logger` is a convenience wrapper around `debug` that adds level based coloured output. Each instance of `debug-logger` contains 2 instances of `debug`, one for general purpose logging and another using `namespace:debug` for debug logs.
 
 AppsCot uses `debug-logger` in [waterline-orientdb](https://github.com/appscot/waterline-orientdb).
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 debug-logger
 ============
 
-A thin wrapper for visionmedia's debug logger, adding levels and colored output.
+A thin wrapper for visionmedia/debug logger, adding levels and colored output.
 
 ## Overview
 [visionmedia/debug](https://github.com/visionmedia/debug) is a ubitiquous logging library with 1000+ dependants. Given how widespread it is and the convenience of namespaces it is a great logger for library modules.
@@ -99,17 +99,20 @@ sillyLog.silly("I'm a silly output");
 More examples in the [examples folder](https://github.com/appscot/debug-logger/blob/master/examples/index.js).
 
 ## Methods
-###### `log.debug(message, [Error|Object])`
-###### `log.info(message, [Error|Object])`
-###### `log.warn(message, [Error|Object])`
-###### `log.error(message, [Error|Object])`
-Prints the message prepended by log level. If the terminal supports colors, the level will be one of: blue, green, yellow, red. If an Error is provided, the toString() and call stack will be outputted. If an Object is provided the toString() and util.inspect() will be outputted. Example:
+#### `log.trace([data][, ...])`
+#### `log.debug([data][, ...])`
+#### `log.log([data][, ...])`
+#### `log.info([data][, ...])`
+#### `log.warn([data][, ...])`
+#### `log.error([data][, ...])`
+Prints the data prepended by log level. If the terminal supports colors, the level will be one of: blue, green, yellow, red. If an Error is provided, the toString() and call stack will be outputted. If an Object is provided the toString() and util.inspect() will be outputted. Example:
 ```
   myapp:debug DEBUG  I'm a debug output +0ms
   myapp       INFO   I'm an info output +1ms
 ```
+This function can take multiple arguments in a printf()-like way, if formatting elements are not found in the first string then util.inspect is used on each argument.
 
-###### `getForeColor(color)`
+#### `getForeColor(color)`
 Returns an ANSI foreground color code string. `color` is one of `black, red, green, yellow, blue, magenta, cyan, white`
 Example:
 ``` javascript
@@ -117,12 +120,12 @@ Example:
   // returns '\x1b[36m'
 ```
 
-###### `getBackColor(color)`
+#### `getBackColor(color)`
 Returns an ANSI background color code string.
 
-## Properties
-###### `log[level].logger`
+
+#### `log[level].logger()`
 Returns the default debug instance used by `level`.
 
-###### `log[level].enabled`
+#### `log[level].enabled()`
 Boolean indicating if `level`'s logger is enabled.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ sillyLog.silly("I'm a silly output");
 More examples in the [examples folder](https://github.com/appscot/debug-logger/blob/master/examples/index.js).
 
 ## Methods
+
+### Instance Methods
+
 #### `log.trace([data][, ...])`
 #### `log.debug([data][, ...])`
 #### `log.log([data][, ...])`
@@ -112,6 +115,14 @@ Prints the data prepended by log level. If the terminal supports colors, the lev
 ```
 This function can take multiple arguments in a printf()-like way, if formatting elements are not found in the first string then util.inspect is used on each argument.
 
+#### `log[level].logger()`
+Returns the default debug instance used by `level`.
+
+#### `log[level].enabled()`
+Boolean indicating if `level`'s logger is enabled.
+
+### Module Methods
+
 #### `getForeColor(color)`
 Returns an ANSI foreground color code string. `color` is one of `black, red, green, yellow, blue, magenta, cyan, white`
 Example:
@@ -124,8 +135,5 @@ Example:
 Returns an ANSI background color code string.
 
 
-#### `log[level].logger()`
-Returns the default debug instance used by `level`.
-
-#### `log[level].enabled()`
-Boolean indicating if `level`'s logger is enabled.
+#### `debug`
+Returns visionmedia/debug module.

--- a/debug-logger.js
+++ b/debug-logger.js
@@ -57,7 +57,8 @@ exports.levels = {
 
 exports.styles = {
   bold      : '\x1b[1m',
-  underline : '\x1b[4m'
+  underline : '\x1b[4m',
+  inverse   : '\x1b[7m'
 };
 
 function getLogLevel(namespace) {
@@ -172,7 +173,7 @@ function getDebugInstance(namespace){
 
 function debugLogger(namespace) {
   var levels = exports.levels;
-  var defaultPadding = '\n' + getPadding(2);
+  var defaultPadding = '\n';
   var debugLoggers = { 'default': getDebugInstance.bind(this, namespace) };
 
   var logger = {};
@@ -186,13 +187,13 @@ function debugLogger(namespace) {
     var levelLogger = debugLoggers[loggerNamespaceSuffix];
     var color = vmDebug.useColors ? levels[levelName].color : '';
     var reset = vmDebug.useColors ? exports.colorReset : '';
-    var underline = vmDebug.useColors ? exports.styles.underline : '';
+    var inspectionHighlight = vmDebug.useColors ? exports.styles.bold : '';
 
     logger[levelName] = function () {
       if (logger.logLevel > logger[levelName].level) { return; }
       
       var levelLog = levelLogger();
-      if (hasFormattingElements(arguments[0])){
+      if (isString(arguments[0]) && hasFormattingElements(arguments[0])){
         arguments[0] = color + levels[levelName].prefix + reset + arguments[0];
         return levelLog.apply(this, arguments);
       }
@@ -205,11 +206,12 @@ function debugLogger(namespace) {
       var inspections = "";
       
       var i, param;
+      var n = 1;
       for(i=0; i<errorStrings.length; i++){
         param = errorStrings[i];
         message += param[0];
         if (param.length > 1) {
-          inspections += defaultPadding + underline + param[1] + ' (' + (i+1) + '/' + errorStrings.length + '):' + reset + '\n' + param[2];
+          inspections += defaultPadding + inspectionHighlight + '\\/\\/ ' + param[1] + ' #' + n++ + ' \\/\\/' + reset + '\n' + param[2];
         }
       };
       

--- a/debug-logger.js
+++ b/debug-logger.js
@@ -211,7 +211,8 @@ function debugLogger(namespace) {
         param = errorStrings[i];
         message += param[0];
         if (param.length > 1) {
-          inspections += defaultPadding + inspectionHighlight + '\\/\\/ ' + param[1] + ' #' + n++ + ' \\/\\/' + reset + '\n' + param[2];
+          var highlightStack = param[1].indexOf('Stack') >= 0 ? color : '';
+          inspections += defaultPadding + inspectionHighlight + '\\/\\/ ' + param[1] + ' #' + n++ + ' \\/\\/' + reset + '\n' + highlightStack + param[2] + reset;
         }
       };
       

--- a/debug-logger.js
+++ b/debug-logger.js
@@ -155,29 +155,29 @@ function debugLogger(namespace) {
   var logger = {};
   logger.logLevel = getLogLevel(namespace);
   
-  Object.keys(levels).forEach(function(level) {
-    var loggerNamespaceSuffix = levels[level].namespaceSuffix ? levels[level].namespaceSuffix : 'default';
+  Object.keys(levels).forEach(function(levelName) {
+    var loggerNamespaceSuffix = levels[levelName].namespaceSuffix ? levels[levelName].namespaceSuffix : 'default';
     if(!debugLoggers[loggerNamespaceSuffix]){
       debugLoggers[loggerNamespaceSuffix] = getDebugInstance.bind(this, namespace + loggerNamespaceSuffix);
     }
     var levelLogger = debugLoggers[loggerNamespaceSuffix];
-    var color = vmDebug.useColors ? levels[level].color : '';
+    var color = vmDebug.useColors ? levels[levelName].color : '';
     var reset = vmDebug.useColors ? exports.colorReset : '';
 
-    logger[level] = function (message, e) {
+    logger[levelName] = function (message, e) {
       // console.log('-> No. debug instances: ' + Object.keys(debugInstances).length);
-      if(logger.logLevel > logger[level].level){
+      if(logger.logLevel > logger[levelName].level){
         return;
       }
       var errorStrings = getErrorMessage(e);
       var padding = errorStrings[1] !== '' ? defaultPadding : '';
       var levelLog = levelLogger();
-      levelLog(color + levels[level].prefix + reset + message + errorStrings[0] + padding + errorStrings[1]);
+      levelLog(color + levels[levelName].prefix + reset + message + errorStrings[0] + padding + errorStrings[1]);
     };
     
-    logger[level].level = levels[level].level;
-    logger[level].logger  = function(){ return levelLogger(); };
-    logger[level].enabled = function(){ return levelLogger().enabled; };
+    logger[levelName].level = levels[levelName].level;
+    logger[levelName].logger  = function(){ return levelLogger(); };
+    logger[levelName].enabled = function(){ return levelLogger().enabled; };
   });
 
   return logger;

--- a/debug-logger.js
+++ b/debug-logger.js
@@ -5,6 +5,7 @@ var vmDebug = require('debug');
 exports = module.exports = debugLogger;
 exports.getForeColor = getForeColor;
 exports.getBackColor = getBackColor;
+exports.debug = vmDebug;
 
 exports.inspectOptions = {};
 
@@ -212,7 +213,9 @@ function debugLogger(namespace) {
         message += param[0];
         if (param.length > 1) {
           var highlightStack = param[1].indexOf('Stack') >= 0 ? color : '';
-          inspections += defaultPadding + inspectionHighlight + '\\/\\/ ' + param[1] + ' #' + n++ + ' \\/\\/' + reset + '\n' + highlightStack + param[2] + reset;
+          inspections += defaultPadding +
+            inspectionHighlight + '\\/\\/ ' + param[1] + ' #' + n++ + ' \\/\\/' + reset + '\n' +
+            highlightStack + param[2] + reset;
         }
       };
       

--- a/debug-logger.js
+++ b/debug-logger.js
@@ -107,6 +107,17 @@ function isString(str){
   return typeof str === 'string' || str instanceof String;
 }
 
+function hasFormattingElements(str){
+  if(!str) { return false; }
+  var res = false;
+  ['%s', '%d', '%j'].forEach(function(elem){
+    if(str.indexOf(elem) >= 0) { 
+      res = true; 
+    }
+  });
+  return res;
+}
+
 function getErrorMessage(e) {
   var errorStrings = [' ' + e];
 
@@ -179,7 +190,13 @@ function debugLogger(namespace) {
 
     logger[levelName] = function () {
       if (logger.logLevel > logger[levelName].level) { return; }
+      
       var levelLog = levelLogger();
+      if (hasFormattingElements(arguments[0])){
+        arguments[0] = color + levels[levelName].prefix + reset + arguments[0];
+        return levelLog.apply(this, arguments);
+      }
+      
       var selfArguments = arguments;
       var errorStrings = Object.keys(selfArguments).map(function(key){
         return getErrorMessage(selfArguments[key]);

--- a/debug-logger.js
+++ b/debug-logger.js
@@ -21,6 +21,11 @@ exports.colors = {
 exports.colorReset = '\x1b[0m';
 
 exports.levels = {
+  trace : {
+    color : getForeColor('cyan'),
+    prefix :       'TRACE  ',
+    namespaceSuffix : ':trace'
+  },
   debug : {
     color : getForeColor('blue'),
     prefix :       'DEBUG  ',
@@ -105,6 +110,7 @@ function debugLogger(namespace) {
     var reset = vmDebug.useColors ? exports.colorReset : '';
 
     logger[level] = function (message, e) {
+      // console.log('-> No. debug instances: ' + Object.keys(debugInstances).length);
       var errorStrings = getErrorMessage(e);
       var padding = errorStrings[1] !== '' ? defaultPadding : '';
       var levelLog = levelLogger();

--- a/debug-logger.js
+++ b/debug-logger.js
@@ -165,7 +165,6 @@ function debugLogger(namespace) {
     var reset = vmDebug.useColors ? exports.colorReset : '';
 
     logger[levelName] = function (message, e) {
-      // console.log('-> No. debug instances: ' + Object.keys(debugInstances).length);
       if(logger.logLevel > logger[levelName].level){
         return;
       }

--- a/examples/index.js
+++ b/examples/index.js
@@ -79,7 +79,11 @@ if (!log.log.enabled()) {
   // This only runs if environment variable DEBUG includes "myapp" namespace
   console.log("You probably haven't seen much because the default logger is disabled");
   console.log("Please add 'myapp' namespace to DEBUG environment variable and try again");
-  console.log("e.g.: export DEBUG=$DEBUG,myapp\n");
+  console.log("e.g.: export DEBUG=$DEBUG,myapp");
+} else {
+  console.log("\nNow set DEBUG_LEVEL environment variable to warn and run this example again");
+  console.log("e.g.: export DEBUG_LEVEL=warn");
 }
+console.log();
 
 

--- a/examples/index.js
+++ b/examples/index.js
@@ -25,6 +25,8 @@ var err = new Error('error message');
 err.stack = 'the stack\nline2\nline3';
 log.error('Something failed:', err);
 
+console.log();
+log.log("Multiple", "arguments", "including", "objects:", { obj: 'obj'}, ", makes life easier");
 
 console.log();
 log.info.logger()("the default instance of debug, using 'myapp' namespace");

--- a/examples/index.js
+++ b/examples/index.js
@@ -27,6 +27,7 @@ log.error('Something failed:', err);
 
 console.log();
 log.log("Multiple", "arguments", "including", "objects:", { obj: 'obj'}, ", makes life easier");
+log.warn("util.format style string: %s, number: %d, json: %j.", "a String", 13, { obj: 'json'});
 
 console.log();
 log.info.logger()("the default instance of debug, using 'myapp' namespace");

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,6 +1,7 @@
 var log = require('..')('myapp');
 
 // The below only shows up if environment variable DEBUG includes "myapp" namespace
+log.trace("I'm a trace output");
 log.debug("I'm a debug output");
 log.log("I'm a log output");
 log.info("I'm an info output");
@@ -63,6 +64,14 @@ if(sillyLog.silly.enabled()){
   sillyLog.silly("I'm a silly output");
 } else {
   console.log("Silly is disabled, please add 'myapp:silly' namespace to DEBUG environment variable");
-  console.log("e.g.: export DEBUG=$DEBUG,myapp:silly");
+  console.log("e.g.: export DEBUG=$DEBUG,myapp:silly\n");
 }
+
+if (!log.log.enabled()) {
+  // This only runs if environment variable DEBUG includes "myapp" namespace
+  console.log("You probably haven't seen much because the default logger is disabled");
+  console.log("Please add 'myapp' namespace to DEBUG environment variable and try again");
+  console.log("e.g.: export DEBUG=$DEBUG,myapp\n");
+}
+
 

--- a/examples/index.js
+++ b/examples/index.js
@@ -10,7 +10,7 @@ log.error("I'm an error output");
 
 console.log();
 var debugLogger = require('..');
-if (log.debug.enabled) {
+if (log.debug.enabled()) {
   // This only runs if environment variable DEBUG includes "myapp:debug" namespace
   log.debug("Debug is enabled, let's inspect 'debugLogger.levels':", debugLogger.levels);
 } else {
@@ -26,8 +26,8 @@ log.error('Something failed:', err);
 
 
 console.log();
-log.info.logger("the default instance of debug, using 'myapp' namespace");
-log.debug.logger("the debug instance of debug, using 'myapp:debug' namespace");
+log.info.logger()("the default instance of debug, using 'myapp' namespace");
+log.debug.logger()("the debug instance of debug, using 'myapp:debug' namespace");
 
 
 console.log();
@@ -58,8 +58,8 @@ debugLogger.levels.silly = {
   namespaceSuffix : ':silly'
 };
 var sillyLog = debugLogger('myapp');
-sillyLog.info("Is silly logger enabled? " + sillyLog.silly.enabled);
-if(sillyLog.silly.enabled){
+sillyLog.info("Is silly logger enabled? " + sillyLog.silly.enabled());
+if(sillyLog.silly.enabled()){
   sillyLog.silly("I'm a silly output");
 } else {
   console.log("Silly is disabled, please add 'myapp:silly' namespace to DEBUG environment variable");

--- a/examples/index.js
+++ b/examples/index.js
@@ -25,17 +25,22 @@ var err = new Error('error message');
 err.stack = 'the stack\nline2\nline3';
 log.error('Something failed:', err);
 
+
 console.log();
 log.warn("You can use log.<level>(err) and the stack trace is printed on the level's color");
 log.warn(err);
 
+
 console.log();
-log.log("Multiple", "arguments", "including", "objects:", { obj: 'obj'}, ", makes life easier");
+log.log("Multiple", "arguments", "including", "objects:", { obj: 'obj'}, "makes life easier");
 log.warn("util.format style string: %s, number: %d and json: %j.", "foo", 13, { obj: 'json'});
+
 
 console.log();
 log.info.logger()("the default instance of debug, using 'myapp' namespace");
 log.debug.logger()("the debug instance of debug, using 'myapp:debug' namespace");
+var debug = debugLogger.debug('myapp:visionmedia');
+debug('Nothing tastes better than the original!');
 
 
 console.log();

--- a/examples/index.js
+++ b/examples/index.js
@@ -27,7 +27,7 @@ log.error('Something failed:', err);
 
 console.log();
 log.log("Multiple", "arguments", "including", "objects:", { obj: 'obj'}, ", makes life easier");
-log.warn("util.format style string: %s, number: %d, json: %j.", "a String", 13, { obj: 'json'});
+log.warn("util.format style string: %s, number: %d and json: %j.", "foo", 13, { obj: 'json'});
 
 console.log();
 log.info.logger()("the default instance of debug, using 'myapp' namespace");

--- a/examples/index.js
+++ b/examples/index.js
@@ -56,7 +56,8 @@ console.log();
 debugLogger.levels.silly = {
   color : debugLogger.getForeColor('magenta'),
   prefix : 'SILLY  ',
-  namespaceSuffix : ':silly'
+  namespaceSuffix : ':silly',
+  level : 0
 };
 var sillyLog = debugLogger('myapp');
 sillyLog.info("Is silly logger enabled? " + sillyLog.silly.enabled());

--- a/examples/index.js
+++ b/examples/index.js
@@ -26,6 +26,10 @@ err.stack = 'the stack\nline2\nline3';
 log.error('Something failed:', err);
 
 console.log();
+log.warn("You can use log.<level>(err) and the stack trace is printed on the level's color");
+log.warn(err);
+
+console.log();
 log.log("Multiple", "arguments", "including", "objects:", { obj: 'obj'}, ", makes life easier");
 log.warn("util.format style string: %s, number: %d and json: %j.", "foo", 13, { obj: 'json'});
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "debug-logger",
-  "version": "0.2.0",
-  "description": "A wrapper for visionmedia's debug logger, adding levels and colored output",
+  "version": "0.3.0",
+  "description": "A wrapper for visionmedia/debug logger, adding levels and colored output",
   "main": "debug-logger.js",
   "repository": {
     "type": "git",
@@ -11,7 +11,12 @@
     "debug",
     "logger",
     "levels",
-    "colors"
+    "colors",
+    "colours",
+    "log",
+    "info",
+    "warn",
+    "error"
   ],
   "author": {
     "name": "Dario Marcelino",
@@ -19,6 +24,6 @@
   },
   "license": "MIT",
   "dependencies": {
-    "debug": "~2.1.0"
+    "debug": "^2.1.0"
   }
 }


### PR DESCRIPTION
# v0.3.0
- Lazy loading debug instances: only when they are used for the first time they are actually instantiated;
  - **Note**: this breaks the interface. `log[level].logger` becomes `log[level].logger()` and `log[level].enabled` becomes `log[level].enabled()`.
- Added support for multi arguments (like console.log). Multiple arguments are concatenated using space as separator;
- Added support printf()-like formatting elements (like console.log);
- Added support for a new **DEBUG_LEVEL** env variable where it's possible to restrict the level of output shown. Examples: DEBUG_LEVEL = `warn` | `*:info` | `myapp:2,otherapp:debug`
- Some highlight changes, most importantly stack trace will be printed in the same color as the level (e.g. red for error);
- Added trace level.
