### PR TITLE
v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ log.info("let's inspect 'obj'", obj);
 
 ### Original `debug` instances and enabled property
 ```javascript
-log.info.logger()("the default instance of debug, using 'myapp' namespace");
 log.debug.logger()("the debug instance of debug, using 'myapp:debug' namespace");
+var debug = debugLogger.debug('myapp:visionmedia');
+debug('Nothing tastes better than the original!');
 
 if (log.debug.enabled()) {
   // This only runs if environment variable DEBUG includes "myapp:debug" namespace
@@ -97,7 +98,14 @@ sillyLog.silly("I'm a silly output");
 ```
 ![add log levels](https://raw.githubusercontent.com/wiki/appscot/debug-logger/silly.png)
 
-### Filter log level (instead of namespace)
+### Multiple arguments / util.format style
+```javascript
+log.log("Multiple", "arguments", "including", "objects:", { obj: 'obj'}, "makes life easier");
+log.warn("util.format style string: %s, number: %d and json: %j.", "foo", 13, { obj: 'json'});
+```
+![multiple arguments](https://raw.githubusercontent.com/wiki/appscot/debug-logger/arguments.png)
+
+### Filter by log level (instead of namespace)
 ```sh
 export DEBUG_LEVEL=info
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ npm install debug-logger -S
 ```javascript
 var log = require('debug-logger')('myapp');
 
+log.trace("I'm a trace output");
 log.debug("I'm a debug output");
+log.log("I'm a log output");
 log.info("I'm an info output");
 log.warn("I'm a warn output");
 log.error("I'm an error output");
@@ -131,7 +133,7 @@ Boolean indicating if `level`'s logger is enabled.
 ### Module
 
 #### `.config(obj)`
-Configures debug-logger.
+Configures debug-logger. Returns `debug-logger` to allow chaining operations.
 
 #### `.debug`
 Returns visionmedia/debug module.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A thin wrapper for visionmedia/debug logger, adding levels and colored output.
 
 ## Overview
 [visionmedia/debug](https://github.com/visionmedia/debug) is a ubitiquous logging library with 1000+ dependants. Given how widespread it is and the convenience of namespaces it is a great logger for library modules.
-`debug-logger` is a convenience wrapper around `debug` that adds level based coloured output. Each instance of `debug-logger` will lazily instantiate 3 instances of `debug`, one for general purpose logging using `namespace`, another for debug (`namespace:debug`) and another for trace (`namespace:trace`). All this in configurable fashion. `debug-logger` has no dependencies besides `debug`.
+`debug-logger` is a convenience wrapper around `debug` that adds level based coloured output. Each instance of `debug-logger` will lazily instantiate several instances of `debug` such as `namespace:info`, `namespace:warn`, `namespace:error`, etc. All these are configurable. `debug-logger` has no dependencies besides `debug`.
 
 At AppsCot we use `debug-logger` in [waterline-orientdb](https://github.com/appscot/waterline-orientdb).
 
@@ -74,19 +74,18 @@ log.info('By enabling colors we get this nice colored example:', {
 
 ### Customize available log levels
 ```javascript
-debugLogger.levels.error.color = debugLogger.getForeColor('magenta');
-debugLogger.levels.debug.color = debugLogger.getBackColor('cyan') + debugLogger.getForeColor('white');
+debugLogger.levels.error.color = debugLogger.colors.magenta;
+debugLogger.levels.error.prefix = 'ERROR ';
 
 var customColorLog = debugLogger('myapp');
 customColorLog.error("I'm a 'magenta' error output");
-customColorLog.debug("I'm a 'cyan'/'white' debug output");
 ```
 ![customize log](https://raw.githubusercontent.com/wiki/appscot/debug-logger/customize_log.png)
 
 ### Add log levels
 ```javascript
 debugLogger.levels.silly = {
-  color : debugLogger.getForeColor('magenta'),
+  color : debugLogger.colors.magenta,
   prefix : 'SILLY  ',
   namespaceSuffix : ':silly'
 };
@@ -102,7 +101,7 @@ export DEBUG_LEVEL=info
 ```
 Only info level and above logs will be outputted.
 
-More examples in the [examples folder](https://github.com/appscot/debug-logger/blob/master/examples/index.js).
+More examples in the [examples folder](https://github.com/appscot/debug-logger/blob/master/examples).
 
 ## Reference
 
@@ -116,10 +115,10 @@ Assuming log is an instance of debug-logger (`var log = require('debug-logger')(
 #### `log.info([data][, ...])`
 #### `log.warn([data][, ...])`
 #### `log.error([data][, ...])`
-Prints the data prepended by log level. If the terminal supports colors, the level will be one of: blue, green, yellow, red. If an Error is provided, the toString() and call stack will be outputted. If an Object is provided the toString() and util.inspect() will be outputted. Example:
+Prints the data prepended by log level. If the terminal supports colors, each level will have a specific color. If an Error is provided, the toString() and call stack will be outputted. If an Object is provided the toString() and util.inspect() will be outputted. Example:
 ```
-  myapp:debug DEBUG  I'm a debug output +0ms
-  myapp       INFO   I'm an info output +1ms
+  myapp:debug I'm a debug output +0ms
+  myapp:info  I'm an info output +1ms
 ```
 This function can take multiple arguments in a printf()-like way, if formatting elements are not found in the first string then util.inspect is used on each argument.
 
@@ -131,17 +130,8 @@ Boolean indicating if `level`'s logger is enabled.
 
 ### Module
 
-#### `.getForeColor(color)`
-Returns an ANSI foreground color code string. `color` is one of `black, red, green, yellow, blue, magenta, cyan, white`
-Example:
-``` javascript
-  debugLogger.getForeColor('cyan')
-  // returns '\x1b[36m'
-```
-
-#### `.getBackColor(color)`
-Returns an ANSI background color code string.
-
+#### `.config(obj)`
+Configures debug-logger.
 
 #### `.debug`
 Returns visionmedia/debug module.

--- a/debug-logger.js
+++ b/debug-logger.js
@@ -37,35 +37,39 @@ exports.colorReset = '\x1b[0m';
 
 exports.levels = {
   trace : {
-    color : getForeColor('cyan'),
-    prefix :       'TRACE  ',
+    color : exports.colors.cyan,
+    prefix : 'TRACE',
     namespaceSuffix : ':trace',
     level : 0
   },
   debug : {
-    color : getForeColor('blue'),
-    prefix :       'DEBUG  ',
+    color : exports.colors.blue,
+    prefix : 'DEBUG',
     namespaceSuffix : ':debug',
     level : 1
   },
   log : {
     color : '',
-    prefix : '      LOG    ',
+    prefix : '  LOG  ',
+    namespaceSuffix : ':log',
     level : 2
   },
   info : {
-    color : getForeColor('green'),
-    prefix : '      INFO   ',
+    color : exports.colors.green,
+    prefix : ' INFO ',
+    namespaceSuffix : ':info',
     level : 3
   },
   warn : {
-    color : getForeColor('yellow'),
-    prefix : '      WARN   ',
+    color : exports.colors.yellow,
+    prefix : ' WARN ',
+    namespaceSuffix : ':warn',
     level : 4
   },
   error : {
-    color : getForeColor('red'),
-    prefix : '      ERROR  ',
+    color : exports.colors.red,
+    prefix : 'ERROR',
+    namespaceSuffix : ':error',
     level : 5
   }
 };
@@ -179,7 +183,13 @@ function getErrorMessage(e) {
 }
 
 function getForeColor(color){
-  return '\x1b[' + (30 + exports.colors[color]) + 'm';
+  if(!isNaN(color)){
+    return '\x1b[' + (30 + color) + 'm';
+  }
+  else if(exports.colors[color]){
+    return '\x1b[' + (30 + exports.colors[color]) + 'm';
+  }
+  return color;
 }
 
 function getBackColor(color){
@@ -187,9 +197,12 @@ function getBackColor(color){
 }
 
 var debugInstances = {};
-function getDebugInstance(namespace){
+function getDebugInstance(namespace, color){
   if(!debugInstances[namespace]){
     debugInstances[namespace] = vmDebug(namespace);
+    if(!isNaN(color)){
+      debugInstances[namespace].color = color;
+    }
   }
   return debugInstances[namespace]; 
 }
@@ -205,10 +218,10 @@ function debugLogger(namespace) {
   Object.keys(levels).forEach(function(levelName) {
     var loggerNamespaceSuffix = levels[levelName].namespaceSuffix ? levels[levelName].namespaceSuffix : 'default';
     if(!debugLoggers[loggerNamespaceSuffix]){
-      debugLoggers[loggerNamespaceSuffix] = getDebugInstance.bind(this, namespace + loggerNamespaceSuffix);
+      debugLoggers[loggerNamespaceSuffix] = getDebugInstance.bind(this, namespace + loggerNamespaceSuffix, levels[levelName].color);
     }
     var levelLogger = debugLoggers[loggerNamespaceSuffix];
-    var color = vmDebug.useColors ? levels[levelName].color : '';
+    var color = vmDebug.useColors ? getForeColor(levels[levelName].color) : '';
     var reset = vmDebug.useColors ? exports.colorReset : '';
     var inspectionHighlight = vmDebug.useColors ? exports.styles.underline : '';
 

--- a/examples/index.js
+++ b/examples/index.js
@@ -44,7 +44,7 @@ debug('Nothing tastes better than the original!');
 
 
 console.log();
-debugLogger.levels.error.color = debugLogger.getForeColor('magenta');
+debugLogger.levels.error.color = debugLogger.colors.magenta;
 debugLogger.levels.debug.color = debugLogger.getBackColor('cyan') + debugLogger.getForeColor('white');
 var customColorLog = debugLogger('myapp');
 customColorLog.error("I'm a 'magenta' error output");
@@ -66,8 +66,8 @@ log.info('By enabling colors we get this nice colored example:', {
 
 console.log();
 debugLogger.levels.silly = {
-  color : debugLogger.getForeColor('magenta'),
-  prefix : 'SILLY  ',
+  color : debugLogger.colors.magenta,
+  prefix : 'SILLY',
   namespaceSuffix : ':silly',
   level : 0
 };

--- a/examples/index.js
+++ b/examples/index.js
@@ -37,7 +37,6 @@ log.warn("util.format style string: %s, number: %d and json: %j.", "foo", 13, { 
 
 
 console.log();
-log.info.logger()("the default instance of debug, using 'myapp' namespace");
 log.debug.logger()("the debug instance of debug, using 'myapp:debug' namespace");
 var debug = debugLogger.debug('myapp:visionmedia');
 debug('Nothing tastes better than the original!');

--- a/examples/index.js
+++ b/examples/index.js
@@ -1,6 +1,6 @@
 var log = require('..')('myapp');
 
-// The below only shows up if environment variable DEBUG includes "myapp" namespace
+// The below only shows up if environment variable DEBUG includes "myapp:*" namespace
 log.trace("I'm a trace output");
 log.debug("I'm a debug output");
 log.log("I'm a log output");
@@ -12,7 +12,7 @@ log.error("I'm an error output");
 console.log();
 var debugLogger = require('..');
 if (log.debug.enabled()) {
-  // This only runs if environment variable DEBUG includes "myapp:debug" namespace
+  // This only runs if environment variable DEBUG includes "myapp:debug" or "myapp:*" namespace
   log.debug("Debug is enabled, let's inspect 'debugLogger.levels':", debugLogger.levels);
 } else {
   console.log("Debug is disabled, please add 'myapp:debug' namespace to DEBUG environment variable");
@@ -86,10 +86,10 @@ alwaysPrintAtStartOfLineLog.warn('from the start');
 
 
 if (!log.error.enabled()) {
-  // This only runs if environment variable DEBUG includes "myapp" namespace
-  console.log("You probably haven't seen much because the default logger is disabled");
-  console.log("Please add 'myapp' namespace to DEBUG environment variable and try again");
-  console.log("e.g.: export DEBUG=$DEBUG,myapp");
+  // This only runs if environment variable DEBUG includes "myapp:*" namespace
+  console.log("\nYou probably haven't seen much because some loggers are disabled");
+  console.log("Please add 'myapp:*' namespace to DEBUG environment variable and try again");
+  console.log("e.g.: export DEBUG=$DEBUG,myapp:*");
 } else if(log.log.enabled()) {
   console.log("\nNow set DEBUG_LEVEL environment variable to warn and run this example again");
   console.log("e.g.: export DEBUG_LEVEL=warn");

--- a/examples/index.js
+++ b/examples/index.js
@@ -45,10 +45,9 @@ debug('Nothing tastes better than the original!');
 
 console.log();
 debugLogger.levels.error.color = debugLogger.colors.magenta;
-debugLogger.levels.debug.color = debugLogger.getBackColor('cyan') + debugLogger.getForeColor('white');
+debugLogger.levels.error.prefix = 'ERROR ';
 var customColorLog = debugLogger('myapp');
 customColorLog.error("I'm a 'magenta' error output");
-customColorLog.debug("I'm a 'cyan'/'white' debug output");
 
 
 console.log();
@@ -67,7 +66,7 @@ log.info('By enabling colors we get this nice colored example:', {
 console.log();
 debugLogger.levels.silly = {
   color : debugLogger.colors.magenta,
-  prefix : 'SILLY',
+  prefix : 'SILLY ',
   namespaceSuffix : ':silly',
   level : 0
 };

--- a/examples/legacy_0.3.X.js
+++ b/examples/legacy_0.3.X.js
@@ -1,0 +1,48 @@
+/**
+ * Make debug-logger behave like it did in v0.3.X
+ */
+var debugLogger = require('..').config({
+  levels : {
+    trace : {
+      prefix :       'TRACE  '
+    },
+    debug : {
+      prefix :       'DEBUG  '
+    },
+    log : {
+      prefix : '      LOG    ',
+      namespaceSuffix : null
+    },
+    info : {
+      prefix : '      INFO   ',
+      namespaceSuffix : null
+    },
+    warn : {
+      prefix : '      WARN   ',
+      namespaceSuffix : null
+    },
+    error : {
+      prefix : '      ERROR  ',
+      namespaceSuffix : null
+    }
+  }
+});
+
+var log = debugLogger('myapp');
+
+
+// The below only shows up if environment variable DEBUG includes "myapp" namespace
+log.trace("I'm a trace output");
+log.debug("I'm a debug output");
+log.log("I'm a log output");
+log.info("I'm an info output");
+log.warn("I'm a warn output");
+log.error("I'm an error output");
+
+
+console.log();
+debugLogger.levels.debug.color = '\x1b[4' + debugLogger.colors.cyan + 'm' + '\x1b[3' + debugLogger.colors.white + 'm';
+var customColorLog = debugLogger('myapp');
+customColorLog.debug("I'm a 'cyan'/'white' debug output");
+
+console.log();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "debug-logger",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "description": "A wrapper for visionmedia/debug logger, adding levels and colored output",
   "main": "debug-logger.js",
   "repository": {


### PR DESCRIPTION
- Setting the color on `debug` instance itself to match a given level;
- All levels have their own `debug` instance by default with level name added to the namespace;
- Removes INFO, WARN, ERROR, etc prefixes from log message (namespace already includes these);
- Added example on how to configure `debug-logger` the same way as in v0.3.1;
- `.config()` method now supports customizing levels.
